### PR TITLE
Update to Classname

### DIFF
--- a/src/UrbanDictionary.php
+++ b/src/UrbanDictionary.php
@@ -26,7 +26,7 @@ class UrbanDictionary{
 
 		/* find all elements with "definition" class in the DOM using XPath */
 		$finder = new DomXPath($dom);
-		$className = 'definition';
+		$className = 'meaning';
 		$definitionArray = $finder->query("//*[contains(@class, '$className')]");
 
 		/* return the first definition */


### PR DESCRIPTION
UrbanDictionary updated their page, Instead of "definition" it's "meaning" for the class name